### PR TITLE
Fix v-xyz directive transition stall, infinite-animation cutoff, and React example loop wedge

### DIFF
--- a/.changeset/fix-directive-unmount-stall.md
+++ b/.changeset/fix-directive-unmount-stall.md
@@ -1,0 +1,10 @@
+---
+'@animxyz/vue': patch
+'@animxyz/vue3': patch
+'@animxyz/react': patch
+---
+
+Fix transitions hanging forever on elements using the `v-xyz` directive, and infinite animations being cut short by the safety-net timeout.
+
+- vue/vue3: remove the directive `unbind`/`unmounted` `clearXyzElement` cleanup added in 0.6.8. Vue invokes those hooks during the unmount flush, while the `<Transition>` leave is still animating the element, so the cleanup destroyed the animation hook's listeners/timeouts before they could call `done()` — the leave never completed, `after-leave` never fired, and anything sequenced on it (like the docs examples' toggle loop) stalled permanently. The animation hook already tears everything down when the animation resolves.
+- all wrappers: the auto-mode safety-net timeout now accounts for `animation-iteration-count` — finite counts multiply the duration, and `infinite` animations get no safety timeout at all (they legitimately never fire `animationend`; force-completing them froze `iterate-infinite` showcases after one iteration).

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "site",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev", "--prefix", "site"],
-      "port": 4321
+      "port": 4321,
+      "autoPort": true
     }
   ]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,12 @@
       "runtimeArgs": ["run", "dev", "--prefix", "site"],
       "port": 4321,
       "autoPort": true
+    },
+    {
+      "name": "react-example",
+      "runtimeExecutable": "env",
+      "runtimeArgs": ["BROWSER=none", "npm", "start", "--prefix", "examples/react"],
+      "port": 8080
     }
   ]
 }

--- a/examples/react/src/examples/exampleHook.js
+++ b/examples/react/src/examples/exampleHook.js
@@ -1,42 +1,38 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 
+// Time each transition phase gets to run before the toggle fires anyway.
+// Transition end callbacks can be lost entirely — react-transition-group
+// skips onEntered when a transition is interrupted mid-flight — so an
+// in-flight phase is bounded instead of awaited forever.
+const SAFETY_DELAY = 5000
+// Quiet time after the last completed transition before toggling.
+const SETTLE_DELAY = 1000
+
+// Drives the auto-looping examples by flipping `toggled` once the current
+// enter/exit animations settle. The delay is debounced off the transition
+// callbacks rather than counted with a +1/-1 balance: under React 18
+// StrictMode react-transition-group fires onEnter twice for newly mounted
+// children (double componentDidMount) while onEntered fires once, so a
+// counter wedges above zero and the loop dies. Debouncing only assumes
+// callbacks fire at all, not that they pair up.
 export default function exampleHook() {
-	const [animCount, setAnimCount] = useState(0)
-	const [toggled, setToggled] = useState(0)
+	const [toggled, setToggled] = useState(false)
 	const toggleTimeout = useRef(null)
 
-	function clearToggleTimeout() {
+	const armToggle = useCallback((delay) => {
 		clearTimeout(toggleTimeout.current)
-		toggleTimeout.current = null
-	}
-
-	function toggleExample() {
-		setAnimCount(0)
-		clearToggleTimeout()
 		toggleTimeout.current = setTimeout(() => {
-			setToggled(!toggled)
-		}, 1000)
-	}
-
-	function beforeAnim() {
-		setAnimCount((oldAnimCount) => oldAnimCount + 1)
-	}
-
-	function afterAnim() {
-		setAnimCount((oldAnimCount) => oldAnimCount - 1)
-	}
-
-	useEffect(() => {
-		if (animCount === 0) {
-			toggleExample()
-		}
-	}, [animCount])
-
-	useEffect(() => {
-		return () => {
-			clearToggleTimeout()
-		}
+			setToggled((oldToggled) => !oldToggled)
+		}, delay)
 	}, [])
+
+	const beforeAnim = useCallback(() => armToggle(SAFETY_DELAY), [armToggle])
+	const afterAnim = useCallback(() => armToggle(SETTLE_DELAY), [armToggle])
+
+	useEffect(() => {
+		armToggle(SETTLE_DELAY)
+		return () => clearTimeout(toggleTimeout.current)
+	}, [armToggle])
 
 	return {
 		toggled: toggled,

--- a/packages/vue/src/directives/xyz.js
+++ b/packages/vue/src/directives/xyz.js
@@ -1,19 +1,18 @@
 import clsx from 'clsx'
-import { clearXyzElement } from '../../../../utils'
 
 function updateDirective(el, { value }) {
 	el.setAttribute('xyz', clsx(el._xyzOriginal, value))
 }
 
+// NOTE: no `unbind` cleanup here. Vue runs directive `unbind` during the
+// unmount patch, while a <transition> leave is still animating the element —
+// calling clearXyzElement there tears down the animation hook's
+// listeners/timeouts so `done()` never fires and the leave hangs forever.
+// The hook cleans up after itself when the animation resolves.
 export default {
 	bind(el) {
 		el._xyzOriginal = el.getAttribute('xyz')
 		updateDirective(...arguments)
 	},
 	update: updateDirective,
-	unbind(el) {
-		// Tear down any appearVisible IntersectionObserver and pending animation
-		// timeouts so they don't outlive the unmounted element.
-		clearXyzElement(el)
-	},
 }

--- a/packages/vue/src/index.d.ts
+++ b/packages/vue/src/index.d.ts
@@ -36,8 +36,7 @@ export const XyzTransition: Component<unknown, unknown, unknown, XyzTransitionPr
 
 export const XyzTransitionGroup: Component<unknown, unknown, unknown, XyzTransitionGroupProps>
 
-/** `v-xyz` directive: merges the bound value into the element's `xyz` attribute
- *  and tears down any pending animation observers/timeouts on unbind. */
+/** `v-xyz` directive: merges the bound value into the element's `xyz` attribute. */
 export const xyz: DirectiveOptions
 
 declare const VueAnimXyz: PluginObject<never>

--- a/packages/vue3/src/directives/xyz.js
+++ b/packages/vue3/src/directives/xyz.js
@@ -1,19 +1,18 @@
 import clsx from 'clsx'
-import { clearXyzElement } from '../../../../utils'
 
 function updateDirective(el, { value }) {
 	el.setAttribute('xyz', clsx(el._xyzOriginal, value))
 }
 
+// NOTE: no `unmounted` cleanup here. Vue runs directive `unmounted` hooks in
+// the same post-render flush as the unmount, while a <Transition> leave is
+// still animating the element — calling clearXyzElement there tears down the
+// animation hook's listeners/timeouts so `done()` never fires and the leave
+// hangs forever. The hook cleans up after itself when the animation resolves.
 export default {
 	beforeMount(el) {
 		el._xyzOriginal = el.getAttribute('xyz')
 		updateDirective(...arguments)
 	},
 	updated: updateDirective,
-	unmounted(el) {
-		// Tear down any appearVisible IntersectionObserver and pending animation
-		// timeouts so they don't outlive the unmounted element.
-		clearXyzElement(el)
-	},
 }

--- a/packages/vue3/src/index.d.ts
+++ b/packages/vue3/src/index.d.ts
@@ -36,8 +36,7 @@ export const XyzTransition: DefineComponent<XyzTransitionProps>
 
 export const XyzTransitionGroup: DefineComponent<XyzTransitionGroupProps>
 
-/** `v-xyz` directive: merges the bound value into the element's `xyz` attribute
- *  and tears down any pending animation observers/timeouts on unmount. */
+/** `v-xyz` directive: merges the bound value into the element's `xyz` attribute. */
 export const xyz: Directive<HTMLElement, string | string[] | undefined>
 
 declare const VueAnimXyz: Plugin

--- a/utils/getXyzAnimationHook.js
+++ b/utils/getXyzAnimationHook.js
@@ -19,8 +19,12 @@ function parseMaxCssTime(value) {
 
 // Idempotent teardown for a single element: clears the safety-net timeout, the
 // event listeners, and the appear IntersectionObserver. Safe to call multiple
-// times and after the element has already completed. A5 (Vue wrappers) and A6
-// (React wrapper) call this from their unbind/unmounted/onExited cleanup.
+// times and after the element has already completed. The React wrapper calls
+// this from its onExited/unmount cleanup, which runs only after the transition
+// has resolved. The Vue wrappers deliberately do NOT call it from directive
+// unbind/unmounted hooks — Vue fires those during the unmount flush while the
+// leave transition is still animating, so clearing there kills the listeners
+// that would call `done()` and the transition hangs forever.
 export function clearXyzElement(el) {
 	if (!el) return
 	if (el._xyzAppearObserver) {
@@ -87,8 +91,10 @@ export default function (duration, appearVisible) {
 				// `animation-name` overridden, `xyz-none` applied mid-flight — may
 				// never fire `animationend` either, leaving `done()` uncalled and the
 				// wrapper transition hung. Compute a worst-case bound from the
-				// elements' computed animation-duration + animation-delay and always
-				// resolve by then. Falls back to a generous constant when nothing is
+				// elements' computed animation-duration × iteration-count +
+				// animation-delay and resolve by then — unless any animation iterates
+				// infinitely, in which case there is no bound and no safety timeout
+				// (see below). Falls back to a generous constant when nothing is
 				// readable.
 				let maxAnimMs = 0
 				let unbounded = false

--- a/utils/getXyzAnimationHook.js
+++ b/utils/getXyzAnimationHook.js
@@ -91,15 +91,29 @@ export default function (duration, appearVisible) {
 				// resolve by then. Falls back to a generous constant when nothing is
 				// readable.
 				let maxAnimMs = 0
+				let unbounded = false
 				xyzEls.forEach((xyzEl) => {
 					const style = window.getComputedStyle(xyzEl)
+					const iterationValue = style.getPropertyValue('animation-iteration-count')
+					if (iterationValue.indexOf('infinite') !== -1) {
+						unbounded = true
+						return
+					}
+					const iterations = iterationValue.split(',').reduce((max, part) => {
+						const num = parseFloat(part)
+						return isNaN(num) ? max : Math.max(max, num)
+					}, 1)
 					const durationMs = parseMaxCssTime(style.getPropertyValue('animation-duration'))
 					const delayMs = parseMaxCssTime(style.getPropertyValue('animation-delay'))
-					maxAnimMs = Math.max(maxAnimMs, durationMs + Math.max(delayMs, 0))
+					maxAnimMs = Math.max(maxAnimMs, durationMs * iterations + Math.max(delayMs, 0))
 				})
-				// Small buffer so the event path wins in the normal (uncancelled) case.
-				const safetyMs = (maxAnimMs > 0 ? maxAnimMs + 100 : XYZ_AUTO_SAFETY_TIMEOUT)
-				el._xyzAnimSafetyTimeout = setTimeout(xyzAnimDone, safetyMs)
+				// An infinite animation legitimately never fires `animationend` — the
+				// transition is meant to stay active, so no safety net for it.
+				if (!unbounded) {
+					// Small buffer so the event path wins in the normal (uncancelled) case.
+					const safetyMs = (maxAnimMs > 0 ? maxAnimMs + 100 : XYZ_AUTO_SAFETY_TIMEOUT)
+					el._xyzAnimSafetyTimeout = setTimeout(xyzAnimDone, safetyMs)
+				}
 
 				xyzEls.forEach((xyzEl) => {
 					// Remove if element isnt visible


### PR DESCRIPTION
## What changed

Two related sets of animation-lifecycle fixes, plus verification tooling for the React examples.

### Library fixes (`@animxyz/vue`, `@animxyz/vue3`, `@animxyz/react` — patch changeset included)

- **`v-xyz` directive transitions no longer hang forever.** Reverts the directive `unbind`/`unmounted` `clearXyzElement` cleanup added in 0.6.8: Vue fires those hooks during the unmount flush while the `<Transition>` leave is still animating, so the cleanup destroyed the listeners/timeouts that would have called `done()` — the leave never completed and anything sequenced on `after-leave` (like the docs examples' toggle loops) stalled permanently. The animation hook already tears everything down when the animation resolves.
- **Auto-mode safety-net timeout now respects `animation-iteration-count`.** Finite counts multiply the computed duration; `infinite` animations get no safety timeout at all — they legitimately never fire `animationend`, and force-completing them froze `iterate-infinite` showcases after one iteration.
- Comment/docstring updates to match: the `.d.ts` directive docs no longer claim unbind-time teardown, and `clearXyzElement` documents why the Vue wrappers must not call it from directive hooks while the React wrapper safely does from `onExited`.

### React example app fix (`examples/react`)

The three auto-looping examples driven by `exampleHook.js` (DynamicXyz_Basic, DynamicXyz_ByIndex, XyzTransitionGroup_Index) stalled permanently within seconds of load. This was pre-existing (reproduces identically with the v0.6.7 build) and rooted in the hook's `animCount` ±1 counting, which assumes every `onEnter`/`onExit` is matched by exactly one `onEntered`/`onExited`. react-transition-group v4 under React 18 StrictMode breaks that assumption two ways:

1. StrictMode's simulated remount runs `CSSTransition`'s `componentDidMount` twice for every newly mounted child, firing `onEnter` twice while `onEntered` fires once (the first mount's pending end-callback is cancelled). The 81-square group examples logged exactly 162 `beforeAnim` vs 81 `afterAnim` per cycle — `animCount` wedged at +81 immediately.
2. When a transition is interrupted mid-flight (the hook's 1s toggle timer racing the 1000ms enter in the `SwitchTransition` example), the enter is cancelled and `onEntered` never fires, leaking +1 per interruption.

Either way `animCount` never returns to 0, so the toggle timer never re-arms and the example freezes. The hook now debounces off the callbacks instead of counting them: a started transition holds the toggle behind a 5s safety bound, and each completed transition re-arms a 1s settle timer. Same "flip 1s after animations settle" behavior, but extra or missing callbacks only shift timing instead of killing the loop. Also switches to a functional `setToggled` update, removing a stale-closure toggle.

## Verification

- Headless Chrome (`--headless=new` reports the page as visible, so rAF and animation events run) + CDP with a `MutationObserver` per example: before the fix, zero DOM mutations in any example over 20s; after, all three cycle continuously over 45s (12 cycles for Basic, 5–6 for the 81-square examples) with no console errors.
- The directive/iteration-count fixes were verified previously against the docs site examples using a virtual-time headless dump.

## Notes for review

- `exampleHook.js` behavior under StrictMode is a symptom any `@animxyz/react` consumer counting transition callbacks would hit; the library itself just relays what react-transition-group emits, so the fix is scoped to the example app.
- `.claude/launch.json` gained a dev-server entry for `examples/react` (tooling convenience only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)